### PR TITLE
Update component paths based on new naming

### DIFF
--- a/ftrack_locations/ftrack_template_disk.py
+++ b/ftrack_locations/ftrack_template_disk.py
@@ -16,17 +16,6 @@ def get_modified_component_path(path, name, padding, file_type):
     return path.replace(original_filename, replace_text)
 
 
-def get_new_location(session):
-
-    location = session.query(
-        "Location where name is \"project.disk.root\""
-    ).one()
-    location.accessor = ftrack_api.accessor.disk.DiskAccessor(prefix="")
-    location.structure = NewStructure()
-    location.priority = 50
-    return location
-
-
 class NewStructure(ftrack_api.structure.base.Structure):
 
     def get_resource_identifier(self, entity, context=None):
@@ -69,4 +58,15 @@ def get_old_location():
     location = ftrack.ensureLocation("project.disk.root")
     location.setAccessor(ftrack.DiskAccessor(prefix=""))
     location.setStructure(OldStructure())
+    return location
+
+
+def get_new_location(session):
+
+    location = session.query(
+        "Location where name is \"project.disk.root\""
+    ).one()
+    location.accessor = ftrack_api.accessor.disk.DiskAccessor(prefix="")
+    location.structure = NewStructure()
+    location.priority = 50
     return location

--- a/ftrack_locations/ftrack_template_disk.py
+++ b/ftrack_locations/ftrack_template_disk.py
@@ -7,10 +7,7 @@ import ftrack_template
 
 def get_modified_component_path(path, name, padding, file_type):
 
-    if padding:
-        expression = "%0{0}d".format(padding)
-    else:
-        expression = "%d"
+    expression = "%0{0}d".format(padding) if padding else "%d"
 
     replace_text = "{0}/{1}.{2}{3}".format(name, name, expression, file_type)
 


### PR DESCRIPTION
Due to the recent Bait file naming changes, resource identifiers are no longer correctly pointing to the right place.

This hotfix instead of replacing the file extension of the component, replaces the whole filename with the new naming structure.