### PR TITLE
Use shot filenames for sequence component publishes

### DIFF
--- a/ftrack_locations/ftrack_template_disk.py
+++ b/ftrack_locations/ftrack_template_disk.py
@@ -9,9 +9,11 @@ def get_modified_component_path(path, name, padding, file_type):
 
     expression = "%0{0}d".format(padding) if padding else "%d"
 
-    replace_text = "{0}/{1}.{2}{3}".format(name, name, expression, file_type)
-
     original_filename = os.path.basename(path)
+
+    shot_task_version, ext = os.path.splitext(original_filename)
+
+    replace_text = "{0}/{1}.{2}{3}".format(name, shot_task_version, expression, file_type)
 
     return path.replace(original_filename, replace_text)
 


### PR DESCRIPTION
Motivation:

Update sequence component paths based on new template in use at Clothcat.

This goes hand in hand with the core template changes found in the Bait project.