### PR TITLE
Revert "Use shot filenames for sequence component publishes"

### DIFF
--- a/ftrack_locations/ftrack_template_disk.py
+++ b/ftrack_locations/ftrack_template_disk.py
@@ -9,11 +9,9 @@ def get_modified_component_path(path, name, padding, file_type):
 
     expression = "%0{0}d".format(padding) if padding else "%d"
 
+    replace_text = "{0}/{1}.{2}{3}".format(name, name, expression, file_type)
+
     original_filename = os.path.basename(path)
-
-    shot_task_version, ext = os.path.splitext(original_filename)
-
-    replace_text = "{0}/{1}.{2}{3}".format(name, shot_task_version, expression, file_type)
 
     return path.replace(original_filename, replace_text)
 


### PR DESCRIPTION
There has been a large number of components being affected as a result of this change, most noticeably caches where names of the individual cache files no longer make sense.

Eg for the cache group "eddy_Rig_eddy_Geo" the files are named:

S:\episodes\stc_ep104_easycheesy\sc010\sc010sh0240\animation\publish\cache\v015\eddy_Rig_eddy_Geo\sc010sh0240.animation.v015.%04d.abc

Similarly a rig named maggie_Rig_Geo would be located at:

S:\episodes\stc_ep104_easycheesy\sc010\sc010sh0240\animation\publish\cache\v015\maggie_Rig_Geo\sc010sh0240.animation.v015.%04d.abc

You can see that each sequence of files are named the same.

The original problem this solved, naming deadline renders correctly can better be resolved by artists being instructed to name their groups correctly for the dcc in question.

Reverts iwootten/ftrack-locations#2